### PR TITLE
Installer should not be starting the service

### DIFF
--- a/src/installer/Product.wxs
+++ b/src/installer/Product.wxs
@@ -73,7 +73,6 @@
                             ErrorControl="ignore"
                             Interactive="no" />
             <ServiceControl Id="StartService"
-                            Start="install"
                             Stop="both"
                             Remove="uninstall"
                             Name="$(var.ProductName)"


### PR DESCRIPTION
Once CollectdWin is installed, user need to edit the configuration and start the service, so installer should not be starting the service. This will also help troubleshoot issues like #2 where installer couldn't start the service for some reason, so it un-installs and makes troubleshooting harder.
