### PR TITLE
Too many log archive files

### DIFF
--- a/src/CollectdWinService/app.config
+++ b/src/CollectdWinService/app.config
@@ -123,7 +123,7 @@
               keepFileOpen="true"
               ConcurrentWrites="false"
               archiveAboveSize="1048576"
-              archiveFileName="${specialfolder:CommonApplicationData }\${appName}\${appName}_debug_${shortdate}.{##}.log"
+              archiveFileName="${specialfolder:CommonApplicationData }\${appName}\${appName}_debug.{##}.log"
               archiveNumbering="Sequence"
               archiveEvery="Day"
               maxArchiveFiles="10" />


### PR DESCRIPTION
There are more log archives than the maxArchiveFiles settings, this is because date is part of the log archive name.
