### PR TITLE
Add WindowsPerformanceCounter configuration reloads on intervals

### DIFF
--- a/src/CollectdWinService/config/WindowsPerformanceCounter.config
+++ b/src/CollectdWinService/config/WindowsPerformanceCounter.config
@@ -1,4 +1,5 @@
 ﻿<WindowsPerformanceCounter>
+  <ReloadConfiguration Enable="true" Interval="900" />
   <Counters>
     <Counter Category="Processor" Name="% Processor Time" Instance="_Total" CollectdPlugin="aggregation"
              CollectdPluginInstance="cpu-average" CollectdType="cpu" CollectdTypeInstance="processor" />

--- a/src/CollectdWinService/config/WindowsPerformanceCounterPluginConfig.cs
+++ b/src/CollectdWinService/config/WindowsPerformanceCounterPluginConfig.cs
@@ -4,6 +4,30 @@ namespace BloombergFLP.CollectdWin
 {
     internal class WindowsPerformanceCounterPluginConfig : ConfigurationSection
     {
+        [ConfigurationProperty("ReloadConfiguration", IsRequired = true)]
+        public ReloadConfigurationConfig ReloadConfiguration
+        {
+            get { return (ReloadConfigurationConfig)base["ReloadConfiguration"]; }
+            set { base["ReloadConfiguration"] = value; }
+        }
+
+        public sealed class ReloadConfigurationConfig : ConfigurationElement
+        {
+            [ConfigurationProperty("Enable", IsRequired = true)]
+            public bool Enable
+            {
+                get { return (bool)base["Enable"]; }
+                set { base["Enable"] = value; }
+            }
+
+            [ConfigurationProperty("Interval", IsRequired = true)]
+            public int Interval
+            {
+                get { return (int)base["Interval"]; }
+                set { base["Interval"] = value; }
+            }
+        }
+
         [ConfigurationProperty("Counters", IsRequired = false)]
         [ConfigurationCollection(typeof (CounterConfigCollection), AddItemName = "Counter")]
         public CounterConfigCollection Counters


### PR DESCRIPTION
Before this change PerformanceCounter instances that would get
dynamically added to a PerformanceCounterCategory after startup
would not be picked up and collected.

This change adds an option to reload the WindowsPerformanceCounter
configuration and thus re-evaluate any new instances that might
have been added since startup or last configuration reload.

Combined with #14 this fixes #12.
