### PR TITLE
Fix delay in publishing last batch

### DIFF
--- a/src/CollectdWinService/AmqpPlugin.cs
+++ b/src/CollectdWinService/AmqpPlugin.cs
@@ -84,6 +84,11 @@ namespace BloombergFLP.CollectdWin
             }
         }
 
+        public void Flush()
+        {
+            Logger.Trace("Amqp plugin flushing");
+        }
+
         public void StartConnection()
         {
             double now = Util.GetNow();

--- a/src/CollectdWinService/ConsolePlugin.cs
+++ b/src/CollectdWinService/ConsolePlugin.cs
@@ -26,6 +26,11 @@ namespace BloombergFLP.CollectdWin
         {
             Console.WriteLine("ConsolePlugin: {0}", metric.GetMetricJsonStr());
         }
+
+        public void Flush()
+        {
+            Console.WriteLine("ConsolePlugin: flushing");
+        }
     }
 }
 

--- a/src/CollectdWinService/MetricsCollector.cs
+++ b/src/CollectdWinService/MetricsCollector.cs
@@ -150,6 +150,7 @@ namespace BloombergFLP.CollectdWin
         private void WriteThreadProc()
         {
             Logger.Trace("WriteThreadProc() begin");
+            bool needToFlush = false;
             while (_runWriteThread)
             {
                 try
@@ -164,6 +165,7 @@ namespace BloombergFLP.CollectdWin
                         }
                         if (metricValue != null)
                         {
+                            needToFlush = true;
                             metricValue.Interval = _interval;
 
                             _aggregator.Aggregate(ref metricValue);
@@ -180,13 +182,17 @@ namespace BloombergFLP.CollectdWin
                             }
                         }
                     }
-                    foreach (IMetricsPlugin plugin in _plugins)
+                    if (needToFlush)
                     {
-                        var writePlugin = plugin as IMetricsWritePlugin;
-                        if (writePlugin != null)
+                        needToFlush = false;
+                        foreach (IMetricsPlugin plugin in _plugins)
                         {
-                            // flush only if it is a Write plugin                    
-                            writePlugin.Flush();
+                            var writePlugin = plugin as IMetricsWritePlugin;
+                            if (writePlugin != null)
+                            {
+                                // flush only if it is a Write plugin                    
+                                writePlugin.Flush();
+                            }
                         }
                     }
                     if (_metricValueQueue.Count <= 0)

--- a/src/CollectdWinService/MetricsCollector.cs
+++ b/src/CollectdWinService/MetricsCollector.cs
@@ -180,7 +180,19 @@ namespace BloombergFLP.CollectdWin
                             }
                         }
                     }
-                    Thread.Sleep(_interval*1000);
+                    foreach (IMetricsPlugin plugin in _plugins)
+                    {
+                        var writePlugin = plugin as IMetricsWritePlugin;
+                        if (writePlugin != null)
+                        {
+                            // flush only if it is a Write plugin                    
+                            writePlugin.Flush();
+                        }
+                    }
+                    if (_metricValueQueue.Count <= 0)
+                    {
+                        Thread.Sleep(1000);
+                    }
                 }
                 catch (Exception exp)
                 {

--- a/src/CollectdWinService/MetricsPlugin.cs
+++ b/src/CollectdWinService/MetricsPlugin.cs
@@ -20,6 +20,7 @@ namespace BloombergFLP.CollectdWin
     internal interface IMetricsWritePlugin : IMetricsPlugin
     {
         void Write(MetricValue metric);
+        void Flush();
     }
 
     internal class MetricValue

--- a/src/CollectdWinService/MetricsPlugin.cs
+++ b/src/CollectdWinService/MetricsPlugin.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Globalization;
 using NLog;
+using System.Text.RegularExpressions;
 
 namespace BloombergFLP.CollectdWin
 {
@@ -59,6 +60,15 @@ namespace BloombergFLP.CollectdWin
             return (other);
         }
 
+        public string EscapeString(string str)
+        {
+            if (string.IsNullOrEmpty(str))
+            {
+                return (str);
+            }
+            return (Regex.Escape(str));
+        }
+
         public string GetMetricJsonStr()
         {
             IList<DataSource> dsList = DataSetCollection.Instance.GetDataSource(TypeName);
@@ -82,7 +92,7 @@ namespace BloombergFLP.CollectdWin
             string valStr = string.Join(",", Array.ConvertAll(Values, val => val.ToString(CultureInfo.InvariantCulture)));
 
             string res = string.Format(MetricJsonFormat, HostName, PluginName,
-                PluginInstanceName, TypeName, TypeInstanceName, epochStr,
+                EscapeString(PluginInstanceName), TypeName, EscapeString(TypeInstanceName), epochStr,
                 Interval, dsTypesStr, dsNamesStr, valStr);
             return (res);
         }


### PR DESCRIPTION
This PR fixes following:
- WriteHttp plugin groups metrics into batches based on the batchSize. If the last batch is smaller than the batchSize, the metrics in the last batch are delayed until next interval. This is fixed by introducing 'flush()' method which is called by Write thread.
- Escaped plugin and type instance name fields, so that metrics are published as a valid json
