### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#CollectdWin
+# CollectdWin
 
 CollectdWin is a MS Windows service which collects, aggregates and publishes both application and system metrics periodically. These application and system metrics can be used for performance analysis and capacity planning. CollectdWin is very similar to Collectd (https://collectd.org), it was developed because Collectd does not support Windows.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
